### PR TITLE
Fix redundancy: Keep Companies Database only once in the UI

### DIFF
--- a/src/components/AdminDashboard.tsx
+++ b/src/components/AdminDashboard.tsx
@@ -48,7 +48,6 @@ export const AdminDashboard: React.FC = () => {
   return (
     <div className="container mx-auto py-6 space-y-6">
       <div className="flex justify-between items-center">
-        <h1 className="text-3xl font-bold">Companies</h1>
         {session && !isAddingCompany && !editingCompany && (
           <Button onClick={handleAddCompany}>
             <PlusCircle className="mr-2 h-4 w-4" />
@@ -79,7 +78,7 @@ export const AdminDashboard: React.FC = () => {
       ) : (
         <Card>
           <CardHeader>
-            <CardTitle>Companies</CardTitle>
+            <CardTitle>AI Marketing Tools</CardTitle>
             <CardDescription>
               Find AI companies to help my ads and marketing
             </CardDescription>

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -7,7 +7,7 @@ const Admin = () => {
       <div className="container mx-auto py-12 px-4">
         <div className="text-center mb-12">
           <h1 className="text-4xl font-bold tracking-tight text-[#1A1F2C]">
-            Companies
+            Companies <span className="text-transparent bg-clip-text bg-gradient-to-r from-[#9b87f5] to-[#7E69AB]">Database</span>
           </h1>
         </div>
         


### PR DESCRIPTION
This PR fixes the redundancy issue by ensuring Companies Database appears only once in the UI. It restores the gradient-styled Companies Database heading in Admin.tsx while removing redundant headings in other components.